### PR TITLE
Using Huge Pages and Non-Temporal store intrinsics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CXX = g++
-CXXFLAGS = -Iinclude -Wall -Wextra -std=c++17
+CXXFLAGS = -Iinclude -Wall -Wextra -std=c++17 -O2 -g
 
 BUILD_DIR = build
 BIN_DIR = bin
@@ -45,7 +45,7 @@ $(TARGET): $(MAIN_OBJ) $(LIBRARY)
 
 # Compile main
 $(BUILD_DIR)/main.o: main.cpp
-	$(CXX) $(CXXFLAGS) -g -c main.cpp -o $@
+	$(CXX) $(CXXFLAGS) -c main.cpp -o $@
 
 
 # Compile src files
@@ -75,12 +75,28 @@ clean:
 
 #performance analysis
 analyze_performance:
-	perf stat -e cache-references,cache-misses,L1-dcache-loads,L1-dcache-load-misses ./bin/vulcan
+	perf stat -e cache-references,cache-misses,L1-dcache-loads,L1-dcache-load-misses,dTLB-load-misses ./bin/vulcan
 	perf stat -e cycles,instructions,cache-misses,branch-misses ./bin/vulcan
+	sudo perf mem record -d ./bin/vulcan && sudo perf mem report -f --stdio --sort=sym --percent-limit=0
 
+# test performance analysis
+analyze_test_performance:
 	perf stat -e cache-references,cache-misses,L1-dcache-loads,L1-dcache-load-misses ./bin/tests_runner
 	perf stat -e cycles,instructions,cache-misses,branch-misses ./bin/tests_runner
 
 # get machine code
 machine:
 	objdump -D build/main.o
+
+# Check latency, detect bouncing and verify dTLB
+check_latency:
+	perf mem record -d ./bin/vulcan
+	perf mem report --stdio --verbose
+	perf c2c report ./bin/vulcan
+
+# Find error with debugger
+find_error:
+	make
+	gdb ./bin/vulcan
+	run
+	backtrace

--- a/README.md
+++ b/README.md
@@ -18,5 +18,27 @@ To test performance, from the root directory - type these commands in the termin
 1. **perf stat -e cycles,instructions,cache-misses,branch-misses ./bin/vulcan**
 2. **perf stat -e cache-references,cache-misses,L1-dcache-loads,L1-dcache-load-misses ./bin/vulcan**
 
+To find the error using a degugger, use these commands and maintain the ordering:
+1. **make clean**
+2. **make find_error**
+3. **run** - if successfully entered the GDB Shell
+4. **backtrace**
+
 Currently working on:
 1. **Lock-free SPSC circular Queue**
+This Queue stores QueueOrder instances inside it upto a certain capacity. Its created inside the pre-allocated memory directly using placement new in static factory method. It contains 2 member variables 
+(one for each thread - producer and consumer) with each of the member variables aligned according to 64-bytes for preventing False Sharing. A single Huge Page (2mb size) allocation had been made using the build
+script first for the pre-allocated memory.
+
+Filling the entire allocated block (2 mb) of a Huge Page with the byte value: 0x00 for deterministic warming of scope and value. 
+To solve **problem number 4**, 4 steps need to be taken - Modifying GRUB config -> Declaring Pool size -> Committing and Persistent Pinning -> Verification
+
+Current problems:
+1. My AMD Zen 3 has L1 Data Cache per core of 32 kb. So, if I create the SPSC Queue with 1024 capacity, so the memory needed to store the QueueOrders = 1024 * 64 = 64 kb, which is more than L1 cache
+  capacity. So, reducing the capacity to 256 since now the memory required = 16 kb and the assertion that capacity should be a power of 2 is also satisfied
+2. The calling of memset(obj, 0x00, sizeof(*obj)) is a "Cold Path" solution but inefficient. While it warms the physical memory, but doesn't address the Store-To-Load Forwarding conflicts that
+   can occur when transitioning from initializing buffer to high-speed matching loop
+3. Replacing the memset function call in create function with Non-Temporal Store intrinsics (e.g., _mm_stream_si128), but facing a C++ type-safety violation. 
+4. Currently facing Physical Memory Fragmentation (mmap stops working suddenly even when I have a huge page allocated successfully). This problem was resolved the last time I rebooted the system. Issue:
+   In the AMD Zen 3 architecture, a 2MB Huge Page is not just a size requirement; it is a contiguity requirement. The MMU requires 512 consecutive 4KB physical page frames to back a single huge page. As my 
+   Ubuntu system runs, user-space processes and kernel administrative tasks scatter 4KB allocations across the DRAM, leaving no 2MB gaps of contiguous space.

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,20 @@
+echo "Hello, Rohit!"
+date
+
+# Example using <int, 1024> - replace with your actual types
+CLASS_SIZE=$(printf '#include "include/vulcan/lock_free_spsc_queue.hpp"\n#include <iostream>\nint main(){std::cout << sizeof(LockFreeSPSCQueue<QueueOrder, 4>);}' | g++ -x c++ -I./include -o size_check - && ./size_check && rm size_check)
+echo "The size is: $CLASS_SIZE"
+
+#memory calculation logic:
+# CALCULATED_REQUIREMENT=$((CLASS_SIZE / 2097152))
+# echo "The calculated requirement is: $CALCULATED_REQUIREMENT"
+
+modify_kernel_parameter_hugepages() {
+    if sudo sysctl -w vm.nr_hugepages=1; then
+        echo "NR Hugepages modification successful. Memory reserved = 1 huge page or 2mb";
+    else
+        echo "Hugepages modification not successful. Please try again";
+    fi
+}
+
+modify_kernel_parameter_hugepages

--- a/include/vulcan/lock_free_spsc_queue.hpp
+++ b/include/vulcan/lock_free_spsc_queue.hpp
@@ -3,6 +3,8 @@
 #include <atomic>
 #include <cassert>
 #include <cstddef>
+#include <cstdio>
+#include <sys/mman.h>
 #include <iostream>
 #include <iterator>
 #include <limits>
@@ -31,6 +33,7 @@ class LockFreeSPSCQueue {
         static constexpr size_t mask = capacity - 1;
     };
 
+    static LockFreeSPSCQueue* allocate_huge_pages();
     LockFreeSPSCQueue();
     ~LockFreeSPSCQueue() = default;
     LockFreeSPSCQueue(const LockFreeSPSCQueue&) = delete;
@@ -51,15 +54,29 @@ class LockFreeSPSCQueue {
 };
 
 template<typename T, size_t capacity>
+LockFreeSPSCQueue<T, capacity>* LockFreeSPSCQueue<T, capacity>::allocate_huge_pages() {
+    const size_t boundary = 2 * 1024 * 1024;
+    size_t base_size_of_class = sizeof(LockFreeSPSCQueue<T, capacity>);
+    size_t rounded_size = (base_size_of_class + (boundary - 1)) & ~(boundary - 1);
+    
+    auto* mem_ptr = mmap(NULL, rounded_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | MAP_POPULATE, -1, 0);
+    if (mem_ptr == MAP_FAILED) {
+        perror("mmap");
+        return nullptr;
+    }
+    return mem_ptr;
+}
+
+template<typename T, size_t capacity>
 T* LockFreeSPSCQueue<T, capacity>::buffer() {
     return reinterpret_cast<T*>(reinterpret_cast<char*>(this) + 2 * 64);
 }
 
 template<typename T, size_t capacity>
-LockFreeSPSCQueue<T, capacity>::LockFreeSPSCQueue() : mConsumer{0}, mProducer{0}  {
+LockFreeSPSCQueue<T, capacity>::LockFreeSPSCQueue() : mProducer{0, 0}, mConsumer{0, 0} {
     assert(sizeof(Metadata_Producer) == 64 && "Size of metadata producer should be 64 bytes \n");
     assert(sizeof(Metadata_Consumer) == 64 && "Size of metadata consumer should be 64 bytes \n");
-    assert(reinterpret_cast<uintptr_t>(this)%64 == 0 && "Assertion failed: Non functional core \n");
+    assert(reinterpret_cast<uintptr_t>(this)%64 == 0 && "Assertion failed: Non functional core.. \n");
     assert(mProducer.mask == mConsumer.mask && "Mask in both producer and consumer threads should be equal \n");
     assert(sizeof(QueueOrder) % 64 == 0 && "QueueOrders should be 64 bytes in size \n");
 }
@@ -93,7 +110,7 @@ bool LockFreeSPSCQueue<T, capacity>::push_order_into_queue(const QueueOrder& qOr
         if (next_tail == mProducer.head_cached) { return false; }
     }
     auto buffer_address = reinterpret_cast<std::byte*>(this) + 128 + (tail * 64);
-    new (reinterpret_cast<void*>(buffer_address)) QueueOrder(qOrder);
+    new (reinterpret_cast<void*>(buffer_address)) QueueOrder(qOrder); 
     mProducer.tail.store(next_tail, std::memory_order_release);
     return true;
 }
@@ -106,7 +123,7 @@ bool LockFreeSPSCQueue<T, capacity>::pop_order_from_queue() {
         mConsumer.tail_cached = mProducer.tail.load(std::memory_order_acquire);
         if (head == mConsumer.tail_cached) { return false; }
     }
-    size_t slot_index = head & (capacity - 1);
+    //size_t slot_index = head & (capacity - 1); - popped element
     mConsumer.head.store((head+1)&(capacity-1), std::memory_order_release);
     return true;
 }

--- a/include/vulcan/lock_free_spsc_queue.hpp
+++ b/include/vulcan/lock_free_spsc_queue.hpp
@@ -20,13 +20,13 @@ class LockFreeSPSCQueue {
     static_assert((capacity & (capacity - 1)) == 0, "Capacity must be a power of two");
     public:
     struct alignas(64) Metadata_Producer {
-        std::atomic<size_t> tail = 0;
+        std::atomic<size_t> tail;
         size_t head_cached;
         static constexpr size_t mask = capacity - 1;
     };
 
     struct alignas(64) Metadata_Consumer {
-        std::atomic<size_t> head = 0;
+        std::atomic<size_t> head;
         size_t tail_cached;
         static constexpr size_t mask = capacity - 1;
     };
@@ -56,7 +56,7 @@ T* LockFreeSPSCQueue<T, capacity>::buffer() {
 }
 
 template<typename T, size_t capacity>
-LockFreeSPSCQueue<T, capacity>::LockFreeSPSCQueue() {
+LockFreeSPSCQueue<T, capacity>::LockFreeSPSCQueue() : mConsumer{0}, mProducer{0}  {
     assert(sizeof(Metadata_Producer) == 64 && "Size of metadata producer should be 64 bytes \n");
     assert(sizeof(Metadata_Consumer) == 64 && "Size of metadata consumer should be 64 bytes \n");
     assert(reinterpret_cast<uintptr_t>(this)%64 == 0 && "Assertion failed: Non functional core \n");
@@ -103,7 +103,6 @@ bool LockFreeSPSCQueue<T, capacity>::pop_order_from_queue() {
     size_t head = mConsumer.head.load(std::memory_order_relaxed);
     if (head == mConsumer.tail_cached) {
         //queue appears empty
-        //size_t tail = mProducer.tail.load(std::memory_order_acquire);
         mConsumer.tail_cached = mProducer.tail.load(std::memory_order_acquire);
         if (head == mConsumer.tail_cached) { return false; }
     }

--- a/include/vulcan/lock_free_spsc_queue.hpp
+++ b/include/vulcan/lock_free_spsc_queue.hpp
@@ -4,6 +4,9 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdio>
+#include <exception>
+#include <fstream>
+#include <string>
 #include <sys/mman.h>
 #include <iostream>
 #include <iterator>
@@ -38,6 +41,7 @@ class LockFreeSPSCQueue {
     ~LockFreeSPSCQueue() = default;
     LockFreeSPSCQueue(const LockFreeSPSCQueue&) = delete;
     LockFreeSPSCQueue& operator=(const LockFreeSPSCQueue&) = delete;
+    //bool pre_allocate_huge_page_pool();
     bool push_order_into_queue(const QueueOrder& qOrder);
     static LockFreeSPSCQueue* create();
     static void destroy(LockFreeSPSCQueue* ptr);
@@ -52,20 +56,6 @@ class LockFreeSPSCQueue {
     Metadata_Producer mProducer;
     Metadata_Consumer mConsumer;
 };
-
-template<typename T, size_t capacity>
-LockFreeSPSCQueue<T, capacity>* LockFreeSPSCQueue<T, capacity>::allocate_huge_pages() {
-    const size_t boundary = 2 * 1024 * 1024;
-    size_t base_size_of_class = sizeof(LockFreeSPSCQueue<T, capacity>);
-    size_t rounded_size = (base_size_of_class + (boundary - 1)) & ~(boundary - 1);
-    
-    auto* mem_ptr = mmap(NULL, rounded_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | MAP_POPULATE, -1, 0);
-    if (mem_ptr == MAP_FAILED) {
-        perror("mmap");
-        return nullptr;
-    }
-    return mem_ptr;
-}
 
 template<typename T, size_t capacity>
 T* LockFreeSPSCQueue<T, capacity>::buffer() {
@@ -84,11 +74,28 @@ LockFreeSPSCQueue<T, capacity>::LockFreeSPSCQueue() : mProducer{0, 0}, mConsumer
 //static factory method for class is the buffer allocation
 template<typename T, size_t capacity>
 LockFreeSPSCQueue<T, capacity>* LockFreeSPSCQueue<T, capacity>::create() {
-    void* raw_memory_ptr = nullptr;
-    size_t required_bytes = (capacity * sizeof(QueueOrder) + sizeof(Metadata_Producer) + sizeof(Metadata_Consumer));
-    int returned_result = posix_memalign(&raw_memory_ptr, 64, required_bytes);
-    assert(returned_result == 0 && "Posix memalign assertion failed \n");
-    LockFreeSPSCQueue* obj = new (raw_memory_ptr) LockFreeSPSCQueue();
+    const std::string required_proc_file_path = "/proc/sys/vm/nr_hugepages";
+    std::ifstream proc_file(required_proc_file_path);
+    if (!proc_file.is_open()) {
+        std::cerr << "Could not open file from path: " << required_proc_file_path << " \n";
+        std::terminate();
+    }
+    int current_huge_pages = proc_file.get() - '0';
+    std::cout << "The huge pages value is: " << current_huge_pages << " \n";
+    if (current_huge_pages != 1) {
+        std::cerr << "Huge pages still not 1. Terminating the program \n";
+        std::terminate();
+    }
+    proc_file.close();
+    const size_t boundary = 2 * 1024 * 1024;
+    size_t base_size_of_class = sizeof(LockFreeSPSCQueue<T, capacity>);
+    size_t rounded_size = (base_size_of_class + (boundary - 1)) & ~(boundary - 1);
+    auto* mem_ptr = mmap(NULL, rounded_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | MAP_POPULATE, -1, 0);
+    if (mem_ptr == MAP_FAILED) {
+        perror("mmap");
+        std::terminate();
+    }
+    LockFreeSPSCQueue* obj = new (mem_ptr) LockFreeSPSCQueue();
     return obj;
 }
 
@@ -110,7 +117,7 @@ bool LockFreeSPSCQueue<T, capacity>::push_order_into_queue(const QueueOrder& qOr
         if (next_tail == mProducer.head_cached) { return false; }
     }
     auto buffer_address = reinterpret_cast<std::byte*>(this) + 128 + (tail * 64);
-    new (reinterpret_cast<void*>(buffer_address)) QueueOrder(qOrder); 
+    new (reinterpret_cast<void*>(buffer_address)) QueueOrder(qOrder);
     mProducer.tail.store(next_tail, std::memory_order_release);
     return true;
 }

--- a/include/vulcan/lock_free_spsc_queue.hpp
+++ b/include/vulcan/lock_free_spsc_queue.hpp
@@ -3,7 +3,11 @@
 #include <atomic>
 #include <cassert>
 #include <cstddef>
+#include <cstdint>
 #include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <emmintrin.h>
 #include <exception>
 #include <fstream>
 #include <string>
@@ -13,6 +17,8 @@
 #include <limits>
 #include <new>
 #include <stdatomic.h>
+#include <smmintrin.h>
+#include <xmmintrin.h>
 
 struct alignas(64) QueueOrder {
     uint64_t order_id;
@@ -28,12 +34,14 @@ class LockFreeSPSCQueue {
         std::atomic<size_t> tail;
         size_t head_cached;
         static constexpr size_t mask = capacity - 1;
+        char padding[64 - ( (sizeof(uint64_t) * 2) % 64 )];
     };
 
     struct alignas(64) Metadata_Consumer {
         std::atomic<size_t> head;
         size_t tail_cached;
         static constexpr size_t mask = capacity - 1;
+        char padding[64 - ( (sizeof(uint64_t) * 2) % 64 )];
     };
 
     static LockFreeSPSCQueue* allocate_huge_pages();
@@ -50,7 +58,7 @@ class LockFreeSPSCQueue {
     bool queue_empty();
     int get_queue_current_size();
     int get_front_order_id();
-    T* buffer();
+    __restrict T* buffer();
 
     private:
     Metadata_Producer mProducer;
@@ -58,7 +66,7 @@ class LockFreeSPSCQueue {
 };
 
 template<typename T, size_t capacity>
-T* LockFreeSPSCQueue<T, capacity>::buffer() {
+__restrict T* LockFreeSPSCQueue<T, capacity>::buffer() {
     return reinterpret_cast<T*>(reinterpret_cast<char*>(this) + 2 * 64);
 }
 
@@ -66,6 +74,8 @@ template<typename T, size_t capacity>
 LockFreeSPSCQueue<T, capacity>::LockFreeSPSCQueue() : mProducer{0, 0}, mConsumer{0, 0} {
     assert(sizeof(Metadata_Producer) == 64 && "Size of metadata producer should be 64 bytes \n");
     assert(sizeof(Metadata_Consumer) == 64 && "Size of metadata consumer should be 64 bytes \n");
+    //char* offset_ptr = (char*)obj + 128;
+    //assert();
     assert(reinterpret_cast<uintptr_t>(this)%64 == 0 && "Assertion failed: Non functional core.. \n");
     assert(mProducer.mask == mConsumer.mask && "Mask in both producer and consumer threads should be equal \n");
     assert(sizeof(QueueOrder) % 64 == 0 && "QueueOrders should be 64 bytes in size \n");
@@ -78,13 +88,13 @@ LockFreeSPSCQueue<T, capacity>* LockFreeSPSCQueue<T, capacity>::create() {
     std::ifstream proc_file(required_proc_file_path);
     if (!proc_file.is_open()) {
         std::cerr << "Could not open file from path: " << required_proc_file_path << " \n";
-        std::terminate();
+        std::exit(EXIT_FAILURE);
     }
     int current_huge_pages = proc_file.get() - '0';
     std::cout << "The huge pages value is: " << current_huge_pages << " \n";
     if (current_huge_pages != 1) {
         std::cerr << "Huge pages still not 1. Terminating the program \n";
-        std::terminate();
+        std::exit(EXIT_FAILURE);
     }
     proc_file.close();
     const size_t boundary = 2 * 1024 * 1024;
@@ -93,9 +103,19 @@ LockFreeSPSCQueue<T, capacity>* LockFreeSPSCQueue<T, capacity>::create() {
     auto* mem_ptr = mmap(NULL, rounded_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | MAP_POPULATE, -1, 0);
     if (mem_ptr == MAP_FAILED) {
         perror("mmap");
-        std::terminate();
+        std::exit(EXIT_FAILURE);
     }
     LockFreeSPSCQueue* obj = new (mem_ptr) LockFreeSPSCQueue();
+    char* offset_ptr = (char*)obj + 128;
+    size_t L1_stride = 2048;
+    assert(((uintptr_t)offset_ptr % L1_stride) != 0 && "Buffer offset should not be a multiple of L1 critical stride \n");
+    __m128i* simd_obj_ptr = reinterpret_cast<__m128i*>(&mem_ptr);
+    //__m128i* simd_obj_ptr = reinterpret_cast<__m128i*>(&obj);
+    __m128i zero_vector = _mm_setzero_si128();
+
+    for(size_t i = 0; i < 2*1024*1024; i += 16) {
+        _mm_stream_si128(simd_obj_ptr + i, zero_vector);
+    }
     return obj;
 }
 
@@ -130,7 +150,6 @@ bool LockFreeSPSCQueue<T, capacity>::pop_order_from_queue() {
         mConsumer.tail_cached = mProducer.tail.load(std::memory_order_acquire);
         if (head == mConsumer.tail_cached) { return false; }
     }
-    //size_t slot_index = head & (capacity - 1); - popped element
     mConsumer.head.store((head+1)&(capacity-1), std::memory_order_release);
     return true;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -7,7 +7,7 @@
 #include "vulcan/lock_free_spsc_queue.hpp"
 
 int main() {
-    auto* my_queue = LockFreeSPSCQueue<QueueOrder, 4>::create();
+    auto* my_queue = LockFreeSPSCQueue<QueueOrder, 256>::create();
     std::cout << "The emptyness state of the queue is: " << my_queue->queue_empty() << " \n";
     my_queue->push_order_into_queue({100, 22.32, 232});
     my_queue->push_order_into_queue({101, 23, 49});

--- a/tests/test_lock_free_spsc_queue.cpp
+++ b/tests/test_lock_free_spsc_queue.cpp
@@ -29,7 +29,6 @@ void test_pop_operation_from_queue() {
 }
 
 void test_display_all_orders_in_queue() {
-    //my_queue->display_all_orders_in_queue();
     return;
 }
 
@@ -108,18 +107,31 @@ void test_single_thread_wrap_around() {
     assert(my_local_spsc_queue->queue_empty());
     // Pop from empty queue should fail
     assert(!my_local_spsc_queue->pop_order_from_queue());
-}
+}       
 
 void test_single_thread_full_or_empty_edge() {
     auto* my_local_spsc_queue = LockFreeSPSCQueue<QueueOrder, 2>::create();
-    assert(my_local_spsc_queue->queue_empty() == true && "Queue emptyness assertion failed \n");
-    assert(my_local_spsc_queue->queue_full() == false && "Queue fullness assertion failed \n");
-    assert(my_local_spsc_queue->push_order_into_queue({1, 193.33, 324}) == true && "Push assertion failed, 42 can't be pushed \n");
-    assert(my_local_spsc_queue->queue_empty() == false && "Queue emptyness assertion failed \n");
-    //my_local_spsc_queue->display_all_orders_in_queue();
-    assert(my_local_spsc_queue->queue_full() == true && "Queue fullness assertion failed \n");
-    assert(my_local_spsc_queue->push_order_into_queue({2, 19.32, 484}) == false && "Push assertion failed, 99 can't be pushed \n"); //problem when queue full
-    return;
+    
+    // Empty state
+    assert(my_local_spsc_queue->queue_empty() == true);
+    assert(my_local_spsc_queue->queue_full() == false);
+    
+    // Push 1 element (queue becomes full)
+    assert(my_local_spsc_queue->push_order_into_queue({1, 193.33, 324}) == true);
+    assert(my_local_spsc_queue->queue_empty() == false);
+    assert(my_local_spsc_queue->queue_full() == true);  // Full after 1 element
+    
+    // Try to push 2nd element (should fail - queue full)
+    assert(my_local_spsc_queue->push_order_into_queue({2, 19.32, 484}) == false);
+    
+    // Pop the element (queue becomes empty again)
+    assert(my_local_spsc_queue->pop_order_from_queue() == true);
+    assert(my_local_spsc_queue->queue_empty() == true);
+    assert(my_local_spsc_queue->queue_full() == false);
+    
+    // Now push should work again
+    assert(my_local_spsc_queue->push_order_into_queue({2, 19.32, 484}) == true);
+    assert(my_local_spsc_queue->queue_full() == true);
 }
 
 void test_concurrent_correctness_with_verification() {


### PR DESCRIPTION
- modify: struct atomic variables initialization in class constructor
- fix: test single thread full or empty edge function
- add: shell script to request Huge Pages (2 mb) from the Kernel before running the system
- add: function "create" to secure a 2 mb aligned block directly from the Kernel before object construction
- add: compiler intrinsics in create function to keep the path warm (with Non-Temporal store intrinsics)
- fix: Queue capacity from 1024 to 256 to keep them all in 32 kb L1 cache
- add: make commands to check latency and find errors
- update: Readme